### PR TITLE
artemis-odb-2.0.0 compatibility fixes

### DIFF
--- a/GameLoopSystemInvocationStrategy.java
+++ b/GameLoopSystemInvocationStrategy.java
@@ -19,12 +19,11 @@ package de.tomgrill.artemis;
 
 import com.artemis.BaseSystem;
 import com.artemis.SystemInvocationStrategy;
-import com.artemis.utils.Bag;
+import com.artemis.utils.BitVector;
 import com.badlogic.gdx.utils.Array;
 
 import java.util.concurrent.TimeUnit;
 
-import de.tomgrill.snakerino.Globals;
 
 /**
  * Implements a game loop based on this excellent blog post:
@@ -34,103 +33,145 @@ import de.tomgrill.snakerino.Globals;
  */
 public class GameLoopSystemInvocationStrategy extends SystemInvocationStrategy {
 
-	private final Array<BaseSystem> logicMarkedSystems;
-	private final Array<BaseSystem> otherSystems;
+    private final Array<BaseSystem> logicMarkedSystems;
+    private final Array<BaseSystem> otherSystems;
 
-	private long nanosPerLogicTick; // ~ dt
-	private long currentTime = System.nanoTime();
+    private long nanosPerLogicTick; // ~ dt
+    private long currentTime = System.nanoTime();
 
-	private long accumulator;
+    private long accumulator;
 
-	private boolean systemsSorted = false;
+    private boolean systemsSorted = false;
 
-	public GameLoopSystemInvocationStrategy() {
-		this(40);
-	}
+    private final BitVector disabledlogicMarkedSystems = new BitVector();
+    private final BitVector disabledOtherSystems = new BitVector();
 
-	public GameLoopSystemInvocationStrategy(int millisPerLogicTick) {
-		this.nanosPerLogicTick = TimeUnit.MILLISECONDS.toNanos(millisPerLogicTick);
-		logicMarkedSystems = new Array<BaseSystem>();
-		otherSystems = new Array<BaseSystem>();
-	}
+    public GameLoopSystemInvocationStrategy() {
+        this(40);
+    }
 
-	private void sortSystems(Bag<BaseSystem> systems) {
-		if (!systemsSorted) {
-			Object[] systemsData = systems.getData();
-			for (int i = 0, s = systems.size(); s > i; i++) {
-				BaseSystem system = (BaseSystem) systemsData[i];
-				if (system instanceof LogicRenderMarker) {
-					logicMarkedSystems.add(system);
-				} else {
-					otherSystems.add(system);
-				}
-			}
-			systemsSorted = true;
-		}
-	}
+    @Override
+    protected void initialize() {
+        /** Sort Sytems here in case {@link #setEnabled(BaseSystem, boolean)} is called prior to first {@link #process()} */
+        if (!systemsSorted) {
+            sortSystems();
+        }
+    }
 
-	@Override
-	protected void process(Bag<BaseSystem> systems) {
-		if (!systemsSorted) {
-			sortSystems(systems);
-		}
 
-		long newTime = System.nanoTime();
-		long frameTime = newTime - currentTime;
+    public GameLoopSystemInvocationStrategy(int millisPerLogicTick) {
+        this.nanosPerLogicTick = TimeUnit.MILLISECONDS.toNanos(millisPerLogicTick);
+        logicMarkedSystems = new Array<BaseSystem>();
+        otherSystems = new Array<BaseSystem>();
+    }
 
-		if (frameTime > 250000000) {
-			frameTime = 250000000;    // Note: Avoid spiral of death
-		}
+    private void sortSystems() {
+        if (!systemsSorted) {
+            Object[] systemsData = systems.getData();
+            for (int i = 0, s = systems.size(); s > i; i++) {
+                BaseSystem system = (BaseSystem) systemsData[i];
+                if (system instanceof LogicRenderMarker) {
+                    logicMarkedSystems.add(system);
+                } else {
+                    otherSystems.add(system);
+                }
+            }
+            systemsSorted = true;
+        }
+    }
 
-		currentTime = newTime;
-		accumulator += frameTime;
+    @Override
+    protected void process() {
+        if (!systemsSorted) {
+            sortSystems();
+        }
 
-		// required since artemis-odb-2.0.0-RC4, updateEntityStates() must be called
-		// before processing the first system - in case any entities are
-		// added outside the main process loop
-		updateEntityStates();
+        long newTime = System.nanoTime();
+        long frameTime = newTime - currentTime;
 
-		/**
-		 * Uncomment this line if you use the world's delta within your systems.
-		 * I recommend to use a fixed value for your logic delta like millisPerLogicTick or nanosPerLogicTick
-		 */
+        if (frameTime > 250000000) {
+            frameTime = 250000000;    // Note: Avoid spiral of death
+        }
+
+        currentTime = newTime;
+        accumulator += frameTime;
+
+        // required since artemis-odb-2.0.0-RC4, updateEntityStates() must be called
+        // before processing the first system - in case any entities are
+        // added outside the main process loop
+        updateEntityStates();
+
+        /**
+         * Uncomment this line if you use the world's delta within your systems.
+         * I recommend to use a fixed value for your logic delta like millisPerLogicTick or nanosPerLogicTick
+         */
 //		world.setDelta(nanosPerLogicTick * 0.000000001f);
 
-		while (accumulator >= nanosPerLogicTick) {
-			/** Process all entity systems inheriting from {@link LogicRenderMarker} */
-			for (int i = 0; i < logicMarkedSystems.size; i++) {
-				/**
-				 * Make sure your systems keep the current state before calculating the new state
-				 * else you cannot interpolate later on when rendering
-				 */
-				logicMarkedSystems.get(i).process();
-				updateEntityStates();
-			}
+        while (accumulator >= nanosPerLogicTick) {
+            /** Process all entity systems inheriting from {@link LogicRenderMarker} */
+            for (int i = 0; i < logicMarkedSystems.size; i++) {
+                /**
+                 * Make sure your systems keep the current state before calculating the new state
+                 * else you cannot interpolate later on when rendering
+                 */
+                if (disabledlogicMarkedSystems.get(i)) {
+                    continue;
+                }
+                logicMarkedSystems.get(i).process();
+                updateEntityStates();
+            }
 
-			accumulator -= nanosPerLogicTick;
-		}
+            accumulator -= nanosPerLogicTick;
+        }
 
-		/**
-		 * Uncomment this line if you use the world's delta within your systems.
-		 */
+        /**
+         * Uncomment this line if you use the world's delta within your systems.
+         */
 //		world.setDelta(frameTime * 0.000000001f);
 
-		/**
-		 * When you divide accumulator by nanosPerLogicTick you get your alpha.
-		 * You can store the alpha value in a GameStateComponent f.e.
-		 */
+        /**
+         * When you divide accumulator by nanosPerLogicTick you get your alpha.
+         * You can store the alpha value in a GameStateComponent f.e.
+         */
 //		float alpha = (float) accumulator / nanosPerLogicTick;
 
 
-		/** Process all NON {@link LogicRenderMarker} inheriting entity systems */
-		for (int i = 0; i < otherSystems.size; i++) {
-			/**
-			 * Use the kept state from the logic above and interpolate with the current state within your render systems.
-			 */
-			otherSystems.get(i).process();
-			updateEntityStates();
-		}
+        /** Process all NON {@link LogicRenderMarker} inheriting entity systems */
+        for (int i = 0; i < otherSystems.size; i++) {
+            /**
+             * Use the kept state from the logic above and interpolate with the current state within your render systems.
+             */
+            if (disabledOtherSystems.get(i)) {
+                continue;
+            }
+            otherSystems.get(i).process();
+            updateEntityStates();
+        }
+    }
 
-	}
+    @Override
+    public boolean isEnabled(BaseSystem target) {
+        Array<BaseSystem> systems = (target instanceof LogicRenderMarker) ? logicMarkedSystems : otherSystems;
+        BitVector disabledSystems = (target instanceof LogicRenderMarker) ? disabledlogicMarkedSystems : disabledOtherSystems;
+        Class targetClass = target.getClass();
+        for (int i = 0; i < systems.size; i++) {
+            if (targetClass == systems.get(i).getClass())
+                return !disabledSystems.get(i);
+        }
+        throw new RuntimeException("System not found in this world");
+    }
+
+    @Override
+    public void setEnabled(BaseSystem target, boolean value) {
+        Array<BaseSystem> systems = (target instanceof LogicRenderMarker) ? logicMarkedSystems : otherSystems;
+        BitVector disabledSystems = (target instanceof LogicRenderMarker) ? disabledlogicMarkedSystems : disabledOtherSystems;
+        Class targetClass = target.getClass();
+        for (int i = 0; i < systems.size; i++) {
+            if (targetClass == systems.get(i).getClass()) {
+                disabledSystems.set(i, !value);
+                break;
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
- Update to artemis-odb-2.0.0 requirements as seen [here](https://github.com/junkdog/artemis-odb/wiki/Upgrading-Checklist-2.0.0):
  - bag-of-systems now stored as a field, instead of being passed as a parameter to `InvocationStrategy::process`.
  - `SystemInvocationStrategy`are now responsible for skipping disabled systems. Added logic to keep track of disable system
- presort systems in `Initialize` in case `SystemInvocationStrategy#SetEnabled(BaseSystem system, boolean value)` is called prior to first `process`. 
- removed unnecessary import to external lib
